### PR TITLE
Dev merge for port mapping restructure

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,7 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": []
+}

--- a/main.go
+++ b/main.go
@@ -55,12 +55,18 @@ var (
 			BorderForeground(lipgloss.Color("240"))
 )
 
+type container_port struct {
+	cont_port uint16
+	host_port uint16
+	host_IP string
+}
+
 type container struct {
 	name         string
 	repository   string
 	tag          string
 	exposesPorts bool
-	ports        [][]uint16
+	ports        []container_port
 	outdated     bool
 	imageID      string
 }
@@ -102,15 +108,18 @@ func initialModel() model {
 	containers := []container{}
 
 	for _, container_api := range containers_api {
-		// fmt.Printf("container_api: %+v\n", container_api.Ports)
 
 		exposesPorts := false
 
 		s_port := ""
-		ports := make([][]uint16, len(container_api.Ports))
+		ports := make([]container_port, len(container_api.Ports))
 		for i := range ports {
 			exposesPorts = true
-			ports[i] = []uint16{container_api.Ports[i].PublicPort, container_api.Ports[i].PrivatePort}
+			ports[i] = container_port{
+				host_port: container_api.Ports[i].PublicPort
+				host_IP: container_api.Ports[i].IP
+				cont_port: container_api.Ports[i].PrivatePort
+			}
 
 			if s_port != "" {
 				s_port += ", "
@@ -219,6 +228,11 @@ func (c container) update() {
 		ExposedPorts: nat.PortSet{
 			exposed_port: struct{}{},
 		},
+	}
+
+	port_bindings := []nat.PortBinding{}
+	for _, port in c.ports{
+		(port_bindings)
 	}
 
 	host_config := &container_types.HostConfig{

--- a/portcheck.go
+++ b/portcheck.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+func isHostPortAvailable(port uint16) bool {
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		// Port is in use, return unavailable
+		return false
+	}
+	err = ln.Close()
+	if err != nil {
+		// Oops cannot close the connection, bad news bears
+		panic(err)
+	}
+
+	// Port was detected as available
+	return true
+
+}


### PR DESCRIPTION
This PR corrects the implementation of the ports mapping.
Each port is now mapped individually from the old port to the new port, including protocol and host IP.
If the port cannot be mapped (it is already mapped somehow), then the host port is replaced with a wildcard.
Closes #8 , #2 , #7 